### PR TITLE
Add remove followers functionality

### DIFF
--- a/internal/service/service.go
+++ b/internal/service/service.go
@@ -411,7 +411,7 @@ func (svc *Service) UnFollowAllNotMutualExceptWhitelisted() (int, error) {
 		pBar.Finish()
 	}()
 
-	return svc.processNotMutual(pBar, notMutual)
+	return svc.unfollowUsers(pBar, notMutual)
 }
 
 func (svc *Service) whitelistNotMutual(notMutual []models.User) []models.User {
@@ -430,7 +430,89 @@ func (svc *Service) whitelistNotMutual(notMutual []models.User) []models.User {
 	return result
 }
 
-func (svc *Service) processNotMutual(pBar bar.Bar, notMutual []models.User) (int, error) {
+func (svc *Service) getUsersByUsername(usernames []string) ([]*goinsta.User, error) {
+	users := make([]*goinsta.User, 0)
+	for _, un := range usernames {
+		u, err := svc.instagram.client.Profiles.ByName(un)
+		if err != nil {
+			return nil, err
+		} else {
+
+		}
+		users = append(users, u)
+	}
+
+	return users, nil
+}
+
+func (svc *Service) RemoveFollowersByUsername(usernames []string) (int, error) {
+	pBar := bar.New(len(usernames), getBarType())
+
+	go pBar.Run(svc.ctx)
+
+	defer func() {
+		pBar.Finish()
+	}()
+
+	return svc.removeFollowers(pBar, usernames)
+}
+
+func (svc *Service) removeFollowers(pBar bar.Bar, users []string) (int, error) {
+	var count int
+
+	ticker := time.NewTicker(svc.instagram.sleep)
+	defer ticker.Stop()
+
+	const errsLimit = 3
+
+	var errsNum int
+
+LOOP:
+	for _, un := range users {
+		if errsNum >= errsLimit {
+			return count, ErrCorrupted
+		}
+
+		select {
+		case <-svc.ctx.Done():
+			break LOOP
+		case <-ticker.C:
+			pBar.Progress() <- struct{}{}
+
+			u, err := svc.instagram.client.Profiles.ByName(un)
+			if err != nil {
+				log.Errorf("user lookup failed [%s]: %v", un, err)
+				errsNum++
+				continue
+			}
+
+			if err := u.Block(); err != nil {
+				log.Errorf("failed to block follower [%s]: %v", u.Username, err)
+				errsNum++
+
+				continue
+			}
+			if err := u.Unblock(); err != nil {
+				log.Errorf("failed to unblock follower [%s]: %v", u.Username, err)
+				errsNum++
+
+				continue
+			}
+
+			count++
+
+			if count >= svc.instagram.limits.unFollow {
+				return count, ErrLimitExceed
+			}
+
+			time.Sleep(svc.instagram.sleep)
+		}
+	}
+
+	return count, nil
+}
+
+func (svc *Service) unfollowUsers(pBar bar.Bar, users []models.User) (int, error) {
 	var count int
 
 	ticker := time.NewTicker(svc.instagram.sleep)
@@ -443,7 +525,7 @@ func (svc *Service) processNotMutual(pBar bar.Bar, notMutual []models.User) (int
 	whitelist := svc.instagram.Whitelist()
 
 LOOP:
-	for _, nu := range notMutual {
+	for _, u := range users {
 		if errsNum >= errsLimit {
 			return count, ErrCorrupted
 		}
@@ -452,14 +534,14 @@ LOOP:
 		case <-svc.ctx.Done():
 			break LOOP
 		case <-ticker.C:
-			if _, exist := whitelist[nu.UserName]; exist {
+			if _, exist := whitelist[u.UserName]; exist {
 				continue
 			}
 
 			pBar.Progress() <- struct{}{}
 
-			if err := svc.UnFollow(nu); err != nil {
-				log.Errorf("failed to unfollow [%s]: %v", nu.UserName, err)
+			if err := svc.UnFollow(u); err != nil {
+				log.Errorf("failed to unfollow [%s]: %v", u.UserName, err)
 				errsNum++
 
 				continue


### PR DESCRIPTION
Hi there, I implemented this feature for myself. I'm not sure if you're looking for it but this is was maintained and a great starting point so I figured I should pay it back :). I don't write much Go and did this fairly quickly so very open to any feedback. 

One this I wasn't sure was if I should be sleeping the loop for longer since I'm making 3 requests to the API in a row.

<!-- If applied, this commit will... -->

- Add a new command: `remove-followers` / `remove` / `rm`
- This new command will remove a list of your followers passed in by first blocking then unblocking them.
- Renames `processNotMutual` -> `unfollowUsers` - this seemed like a function that could be used more generally, so I felt renaming it may be nice for the future.

<!-- Why is this change being made? -->

Ghost followers are becoming increasingly important with Instagram's algorithm; users that follow you but are inactive lower your overall engagement, which means your posts/stories/etc are shown to less people.

Initially, I wanted to unfollow a user directly, but this required additional updates to the downstream instagram API package that I didn't want to deal with currently (and I couldn't get it working, haha). 

Blocking and unblocking has the same effect. DMs are left in place and comments + previous likes are only removed for the duration of the block. 

<!-- # Provide links to any relevant tickets, URLs or other resources -->
https://www.techuntold.com/what-happens-when-you-block-someone-on-instagram/
